### PR TITLE
MediaProvider: don't delete entries of secondary storage on shutdown

### DIFF
--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -70,6 +70,7 @@ import android.os.RemoteException;
 import android.os.SystemClock;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
+import android.os.SystemProperties;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.provider.MediaStore;
@@ -254,6 +255,11 @@ public class MediaProvider extends ContentProvider {
                     sFolderArtMap.clear();
                     MiniThumbFile.reset();
                 } else {
+                    // Don't delete entries if the eject is due to shutdown
+                    if (!"".equals(SystemProperties.get("sys.shutdown.requested"))) {
+                        Log.d(TAG, "not deleting entries on eject due to shutdown");
+                        return;
+                    }
                     // If secondary external storage is ejected, then we delete all database
                     // entries for that storage from the files table.
                     DatabaseHelper database;


### PR DESCRIPTION
All rows on external SD card will be deleted by fault due to eject
intent on shutdown is received. Don't proceed under this circumstance.

Change-Id: I7de7d3cdedcd5512f1f3f9541184d099ce7bfd9f
